### PR TITLE
remove duplicates from service response; minor styling changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,9 +109,9 @@ html, body {
       <h2 class="heading md-title">Powerball Results</h2>
     </div>
     <div layout layout-padding layout-align="start center" class="draw-selection">
-      <h3 class="md-subhead">Drawing</h3>
+      <h3 class="md-subhead">Drawing:</h3>
       <md-input-container flex="none">
-        <md-select ng-model="ctrl.selectedDrawingDate" placeholder="Drawing"
+        <md-select ng-model="ctrl.selectedDrawingDate" placeholder="Loading…"
                    md-on-close="ctrl.drawingSelection()">
           <md-option value="custom">Custom…</md-option>
           <md-option ng-if="ctrl.drawings.length" ng-value="draw.date" ng-repeat="draw in ctrl.drawings">{{::draw.date}}</md-option>
@@ -146,7 +146,11 @@ html, body {
     </div>
     <section>
       <md-subheader>
-       <h2 class="md-title md-primary">Your Tickets</h2>
+        <h2 class="md-title md-primary">Your Tickets</h2>
+        <!--<h2 class="md-title md-primary" layout layout-align="space-between center">
+          <span>Your Tickets</span> 
+          <span class="total" ng-if="ctrl.total !== null">Total: {{ctrl.total | currency:"$":0}}</span>
+        </h2>-->
       </md-subheader>
       <div ng-if="!ctrl.cards.length">Add your tickets and see if you won!</div>
       <md-card ng-repeat="card in ctrl.cards" ng-class="{'success': card.score > 0, 'jackpot': card.jackpot, 'card-complete': ctrl.cardComplete(card), 'deleting-ticket': card.deleting}" ng-hide="card.isEdit" class="ticket">
@@ -207,7 +211,7 @@ html, body {
         <md-button md-no-ink class="md-accent" ng-click="ctrl.deleteAllTickets()">Delete All Tickets</md-button>
       </div>
       <div layout="row" layout-align="center center" style="color: rgba(0, 0, 0, 0.56)">
-        <md-button md-no-ink class="md-primary" ng-click="ctrl.showDisclaimerDialog($event)">Disclaimer</md-button>●
+        <md-button md-no-ink class="md-primary" ng-click="ctrl.showDisclaimerDialog($event)">Disclaimer</md-button>
         <md-button md-no-ink class="md-primary" ng-click="ctrl.showInstructionsDialog($event)">Instructions</md-button>
       </div>
     </footer>

--- a/main.js
+++ b/main.js
@@ -24,7 +24,17 @@ numbersCheckerApp.factory('winnumsService', function ($http) {
         promise = $http.get(url).then(function (response) {
           // The then function here is an opportunity to modify the response
           // The return value gets picked up by the then in the controller.
-          angular.forEach(response.data, function (value, key, obj) {
+          
+          // Remove duplicates (necessary until the service is fixed):
+          var data = response.data;
+          var dataParsed = [data[0]];
+          angular.forEach(data, function (value, key) {
+            if (key > 0 && (data[key].date !== data[key - 1].date)) {
+              dataParsed.push(data[key]);
+            }
+          });
+          
+          angular.forEach(dataParsed, function (value, key, obj) {
             var d = new Date(value.date),
                 day = d.getDay(),
                 prefix = '',
@@ -38,12 +48,7 @@ numbersCheckerApp.factory('winnumsService', function ($http) {
                 prefix = 'Today ';
                 prefixSet = true;
               }
-            } else if (value.date === obj[key - 1].date) {
-              console.log('repeat date for obj[' + key + ']: ' + value.date);
-              // obj.splice(key, 1);
             }
-            
-            
             
             if (!prefixSet) {
               prefix = day === 6 ? 'Sat ' : day === 3 ? 'Wed ' : '';
@@ -51,7 +56,7 @@ numbersCheckerApp.factory('winnumsService', function ($http) {
             obj[key].date = prefix + value.date;
           });
           promise = null;
-          return response.data;
+          return dataParsed;
         });
       }
       // Return the promise to the controller

--- a/sw.js
+++ b/sw.js
@@ -113,7 +113,7 @@
 //});
 
 // Version of the offline cache (change this value everytime you want to update cache)
-var CACHE_NAME = 'version_04'              
+var CACHE_NAME = 'version_005'              
 
 // Add a path you want to cache in this list.
 var URLS = [                


### PR DESCRIPTION
The backend still includes duplicate values when getting new results so this change removes them on the client side.