### PR TITLE
Fix issue with Delete All Tickets button

### DIFF
--- a/main.js
+++ b/main.js
@@ -479,8 +479,7 @@ numbersCheckerApp.config(function($mdThemingProvider) {
         if (len) {
           for (var i = 0; i < len; i++) {
             key = localStorage.key(i);
-            // if (key && (key.indexOf('cn-') === 0)) {
-            if (key) {
+            if (key && (key.indexOf('cn-') === 0)) {
               localStorage.removeItem(key);
             }
           }

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-#version_003444
+#version_003445
 
 CACHE:
 /

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Version of the offline cache (change this value everytime you want to update cache)
-var CACHE_NAME = 'version_003444'
+var CACHE_NAME = 'version_003445'
 
 // Add a path you want to cache in this list.
 var URLS = [                


### PR DESCRIPTION
When clicking the Delete All Tickets button, only delete tickets, i.e., not Google Analytics keys.