### PR TITLE
closes 41

### DIFF
--- a/main.js
+++ b/main.js
@@ -474,14 +474,18 @@ numbersCheckerApp.config(function($mdThemingProvider) {
     function clearStoredTickets () {
       if (ctrl.hasLocalStorage) {
         var len = localStorage.length;
+        var indicesToDelete = []; // store indices of keys to delete
         var key = '';
         var val = '';
         if (len) {
           for (var i = 0; i < len; i++) {
             key = localStorage.key(i);
-            if (key && (key.indexOf('cn-') === 0)) {
-              localStorage.removeItem(key);
+            if (key.indexOf('cn-') === 0) {
+              indicesToDelete.push(i);
             }
+          }
+          for (var j = 0; j < indicesToDelete.length; j++) {
+            localStorage.removeItem(localStorage.key(j));
           }
         }
       }

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-#version_003445
+#version_003446
 
 CACHE:
 /

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Version of the offline cache (change this value everytime you want to update cache)
-var CACHE_NAME = 'version_003445'
+var CACHE_NAME = 'version_003446'
 
 // Add a path you want to cache in this list.
 var URLS = [                


### PR DESCRIPTION
The reason saved tickets were not being deleted when clicking the Delete All Tickets button is because the indices were changed during each iteration of the ``for`` loop. This change adds an additional array to store the keys to delete and an additional ``for`` loop to iterate over that array and delete those keys.